### PR TITLE
fix: provide more context to find pull request merged

### DIFF
--- a/functions/dispatcher/dev_workflow/dispatcher/dispatch_event.py
+++ b/functions/dispatcher/dev_workflow/dispatcher/dispatch_event.py
@@ -1,9 +1,10 @@
 import os
 
 
-def dispatch(sns_client, action, github_event_type, message):
+def dispatch(sns_client, payload, github_event_type, message):
 
     if github_event_type == "pull_request":
+        action = payload.get("action", None)
         if action in ["opened", "reopened"]:
             print("pull request opened")
             sns_topic_arn = os.environ.get("PR__OPEN_SNS_TOPIC_ARN", "")
@@ -15,14 +16,16 @@ def dispatch(sns_client, action, github_event_type, message):
             except Exception as e:
                 print(f"Error: {e}")
                 exit(1)
-        elif action in ["merged"]:
-            print("pull request merged")
-            sns_topic_arn = os.environ.get("PR__MERGED_SNS_TOPIC_ARN", "")
-            try:
-                sns_client.publish(
-                    TopicArn=sns_topic_arn,
-                    Message=message,
-                )
-            except Exception as e:
-                print(f"Error: {e}")
-                exit(1)
+        elif action in ["closed"]:
+            # check if the pull request was merged
+            if payload.get("pull_request", {}).get("merged", False):
+                print("pull request merged")
+                sns_topic_arn = os.environ.get("PR__MERGED_SNS_TOPIC_ARN", "")
+                try:
+                    sns_client.publish(
+                        TopicArn=sns_topic_arn,
+                        Message=message,
+                    )
+                except Exception as e:
+                    print(f"Error: {e}")
+                    exit(1)

--- a/functions/dispatcher/dev_workflow/dispatcher/handler.py
+++ b/functions/dispatcher/dev_workflow/dispatcher/handler.py
@@ -58,7 +58,7 @@ def lambda_handler(event, context):
         "key": payload_filename
     }
 
-    dispatch(sns_client, action, github_event_type, json.dumps(dispatch_message))
+    dispatch(sns_client, payload, github_event_type, json.dumps(dispatch_message))
 
     return {
         "isBase64Encoded": False,

--- a/functions/pull_request__merged/dev_workflow/pull_request__merged/handler.py
+++ b/functions/pull_request__merged/dev_workflow/pull_request__merged/handler.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 logger = logging.getLogger()
-logger.setLevel(os.environ.get("LOGGING_LEVEL", logging.INFO))
+logger.setLevel(os.environ.get("LOGGING_LEVEL", logging.DEBUG))
 
 
 def lambda_handler(event, context):


### PR DESCRIPTION
In this pull request, we provide more context to the
dispatcher to identify if it's a pull request merge event.